### PR TITLE
Emojies now can't move outside the image

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -25,6 +25,11 @@ export default function Index() {
     const [pickedEmoji, setPickedEmoji] = useState<ImageSourcePropType | null>(null);
     const imageRef = useRef(null);
 
+    const imageBoundaries = {
+        width: 320,
+        height: 440
+    }
+
     const pickImageAsync = async () => {
         let result = await ImagePicker.launchImageLibraryAsync({
             allowsEditing: true,
@@ -103,7 +108,7 @@ export default function Index() {
                     placeHolderSource={require('@/assets/images/background-image.png')}
                     imageSource={selectedImage}
                 />
-                {pickedEmoji ? <EmojiSticker imageSize={40} stickerSource={pickedEmoji}/> : null}
+                {pickedEmoji ? <EmojiSticker imageSize={40} stickerSource={pickedEmoji} imageBoundaries={imageBoundaries} /> : null}
             </View>
             {
                 showAppOptions ? (

--- a/components/EmojiSticker.tsx
+++ b/components/EmojiSticker.tsx
@@ -3,9 +3,10 @@ import {Gesture, GestureDetector} from 'react-native-gesture-handler';
 import Animated, {useAnimatedStyle, useSharedValue, withSpring} from 'react-native-reanimated';
 
 
-export default function EmojiSticker({imageSize, stickerSource}: {
+export default function EmojiSticker({ imageSize, stickerSource, imageBoundaries }: {
     imageSize: number,
-    stickerSource: ImageSourcePropType
+    stickerSource: ImageSourcePropType,
+    imageBoundaries: { width: number, height: number }
 }) {
     const scaleImage = useSharedValue(imageSize);
     const translateX = useSharedValue(0);
@@ -17,9 +18,13 @@ export default function EmojiSticker({imageSize, stickerSource}: {
             scaleImage.value = imageSize;
         }
     });
+
+    const maxTranslateX = imageBoundaries.width - scaleImage.value;
+    const maxTranslateY = imageBoundaries.height - scaleImage.value;
+
     const panGesture = Gesture.Pan().onChange((event) => {
-        translateX.value += event.changeX;
-        translateY.value += event.changeY;
+        translateX.value = Math.max(0, Math.min(maxTranslateX, translateX.value + event.changeX));
+        translateY.value = Math.max(0, Math.min(maxTranslateY, translateY.value + event.changeY));
     })
     const imageStyles = useAnimatedStyle(() => {
         return {
@@ -55,6 +60,6 @@ export default function EmojiSticker({imageSize, stickerSource}: {
 
 const styles = StyleSheet.create({
     emojiStickerContainer: {
-        top: -350
+        top: -442
     }
 })


### PR DESCRIPTION
In this PR, I fixed that emoji's now can’t move outside the image so below is how i had implemented it:
First, I calculated the boundaries for moving the emoji sticker within the image. I set the top-left corner of emoji rendering as (0, 0) and determined the max right and bottom values by subtracting the sticker size from the image boundaries' width and height. These max values (maxTranslateX and maxTranslateY) ensure the sticker stays within the image.
In the pan gesture, I update the sticker's position, keeping it within the calculated bounds using Math.max and Math.min
Please review the changes and provide any feedback or suggestions for improvement.
Fixes: #3 

https://github.com/Newton-School/adv-course-assignment/assets/145124801/f683ff01-6929-4f1d-9e68-e368363ec71d


