### PR TITLE
[#6] Display alert when attempting to save unmodified photo

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -23,6 +23,7 @@ export default function Index() {
     const [showAppOptions, setShowAppOptions] = useState<boolean>(false);
     const [modalVisible, setModalVisible] = useState<boolean>(false);
     const [pickedEmoji, setPickedEmoji] = useState<ImageSourcePropType | null>(null);
+    const [isModified, setIsModified] = useState<boolean>(false);
     const imageRef = useRef(null);
 
     const pickImageAsync = async () => {
@@ -41,44 +42,49 @@ export default function Index() {
         setShowAppOptions(false);
         setSelectedImage('');
         setPickedEmoji(null);
+        setIsModified(false);
     }
     const onAddSticker = () => {
         setModalVisible(true);
     }
     const onSaveImageAsync = async () => {
-        if (Platform.OS !== 'web') {
-            try {
-                const localUri = await captureRef(imageRef, {
-                    height: 440,
-                    quality: 1,
-                });
+        if (isModified) {
+            if (Platform.OS !== 'web') {
+                try {
+                    const localUri = await captureRef(imageRef, {
+                        height: 440,
+                        quality: 1,
+                    });
 
-                await MediaLibrary.saveToLibraryAsync(localUri);
-                if (localUri) {
-                    alert("Image saved successfully");
+                    await MediaLibrary.saveToLibraryAsync(localUri);
+                    if (localUri) {
+                        alert("Image saved successfully");
+                    }
+                } catch (e) {
+                    alert("An error occurred while saving the image");
                 }
-            } catch (e) {
-                alert("An error occurred while saving the image");
+            } else {
+                try {
+                    if (imageRef.current) {
+                        const dataUrl = await domToImage.toJpeg(imageRef.current, {
+                            width: 320,
+                            height: 440,
+                            quality: 1
+                        });
+                        let link = document.createElement('a');
+                        link.download = 'image.jpeg';
+                        link.href = dataUrl;
+                        link.click();
+                    }
+                } catch (e) {
+                    alert("An error occurred while saving the image");
+                    ;
+                }
+
+
             }
         } else {
-            try {
-                if (imageRef.current) {
-                    const dataUrl = await domToImage.toJpeg(imageRef.current, {
-                        width: 320,
-                        height: 440,
-                        quality: 1
-                    });
-                    let link = document.createElement('a');
-                    link.download = 'image.jpeg';
-                    link.href = dataUrl;
-                    link.click();
-                }
-            } catch (e) {
-                alert("An error occurred while saving the image");
-                ;
-            }
-
-
+            alert("Oh! no, no, no!!!");
         }
 
     }
@@ -128,7 +134,7 @@ export default function Index() {
                 )
             }
             <EmojiPickerModal isVisible={modalVisible} onClose={closeModal}>
-                <EmojiList onSelect={setPickedEmoji} onCLose={closeModal}/>
+                <EmojiList onSelect={setPickedEmoji} onCLose={closeModal} setIsModified={setIsModified}/>
             </EmojiPickerModal>
             <StatusBar style="inverted"/>
         </GestureHandlerRootView>

--- a/components/EmojiList.tsx
+++ b/components/EmojiList.tsx
@@ -2,9 +2,10 @@ import {useState} from 'react';
 import {FlatList, Image, ImageSourcePropType, Platform, Pressable, StyleSheet} from "react-native";
 
 
-export default function EmojiList({onSelect, onCLose}: {
+export default function EmojiList({onSelect, onCLose, setIsModified}: {
     onSelect: (emoji: ImageSourcePropType) => void,
-    onCLose: () => void
+    onCLose: () => void,
+    setIsModified: (value: boolean) => void
 }) {
     const [emojis] = useState([
         require('../assets/emoji1.png'),
@@ -25,6 +26,7 @@ export default function EmojiList({onSelect, onCLose}: {
                     onPress={() => {
                         onSelect(item);
                         onCLose();
+                        setIsModified(true);
                     }}
                     key={index}
                 >


### PR DESCRIPTION
Fixes #6 
Implemented a boolean state to track if an emoji is added to the photo. The save button now checks this state

- If no emoji is added, an alert saying "Oh! no, no, no!!!" is displayed.
- If an emoji is added, the photo is saved successfully.

This ensures that users cannot save unmodified photos and receive appropriate feedback when attempting to do so.


https://github.com/Newton-School/adv-course-assignment/assets/151147245/373527b2-3487-4ea4-bb41-d166bcb00a33

